### PR TITLE
Update JWPlayer from deprecated 6.8 -> 6.9

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -189,7 +189,7 @@ default['islandora']['additionalFunctionalityModules'] = [
 ]
 
 # JWPlayer specific
-default['jwplayer']['version'] = "6.8"
+default['jwplayer']['version'] = "6.9"
 default['jwplayer']['sha256'] = '87ad00cab2759440bc18487d0afc159c569e1b942abf3b171f80d74549d3139f'
 
 # FITS specific


### PR DESCRIPTION
Greetings!

JWPlayer 6.8 binary no longer exists, update to 6.9
