### PR TITLE
edited gemfile.lock bc mixlib-shellout version 1.6.0 was yanked and is n...

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     mixlib-cli (1.5.0)
     mixlib-config (2.1.0)
     mixlib-log (1.6.0)
-    mixlib-shellout (1.6.0)
+    mixlib-shellout (1.6.1)
     multipart-post (2.0.0)
     net-http-persistent (2.9.4)
     net-ssh (2.9.1)


### PR DESCRIPTION
...o longer available. changed to version 1.6.1